### PR TITLE
Automatic flags based on size of BAM file

### DIFF
--- a/gcp_deepvariant_runner.py
+++ b/gcp_deepvariant_runner.py
@@ -58,12 +58,14 @@ import os
 import subprocess
 import urlparse
 import uuid
+import enum
 
 import gke_cluster
 from google.api_core import exceptions as google_exceptions
 from google.cloud import storage
 
 
+_BAM_FILE_SUFFIX = '.bam'
 _CRAM_FILE_SUFFIX = '.cram'
 _GZ_FILE_SUFFIX = '.gz'
 _BAI_FILE_SUFFIX = '.bai'
@@ -165,6 +167,62 @@ _POD_CONFIG_TEMPLATE = r"""
     }}
 }}
 """
+
+# Following const values are used to automatically set the computational flags.
+_WGS_MODEL_IDENTIFIER = 'wgs_standard'
+_WES_MODEL_IDENTIFIER = 'wes_standard'
+_WES_LARGE_THR = 12 * 1024 * 1024 * 1024
+_WGS_LARGE_THR = 200 * 1024 * 1024 * 1024
+_WGS_SMALL_THR = 25 * 1024 * 1024 * 1024
+
+
+class BamCategories(enum.Enum):
+  """List of BAM categories that determine automatically assigned flags."""
+  WES_SMALL = 0
+  WES_LARGE = 1
+  WGS_SMALL = 2
+  WGS_MEDIUM = 3
+  WGS_LARGE = 4
+
+
+# Default optimal computational flag values, one per BAM category.
+_DEFAULT_FLAGS = {}
+_DEFAULT_FLAGS[BamCategories.WES_SMALL] = {
+    'make_examples_workers': 8,
+    'make_examples_cores_per_worker': 1,
+    'call_variants_workers': 1,
+    'call_variants_cores_per_worker': 4,
+    'gpu': True
+}
+_DEFAULT_FLAGS[BamCategories.WES_LARGE] = {
+    'make_examples_workers': 16,
+    'make_examples_cores_per_worker': 1,
+    'call_variants_workers': 2,
+    'call_variants_cores_per_worker': 4,
+    'gpu': True
+}
+_DEFAULT_FLAGS[BamCategories.WGS_SMALL] = {
+    'make_examples_workers': 32,
+    'make_examples_cores_per_worker': 1,
+    'call_variants_workers': 4,
+    'call_variants_cores_per_worker': 4,
+    'gpu': True
+}
+_DEFAULT_FLAGS[BamCategories.WGS_MEDIUM] = {
+    'make_examples_workers': 64,
+    'make_examples_cores_per_worker': 1,
+    'tpu': True
+}
+_DEFAULT_FLAGS[BamCategories.WGS_LARGE] = {
+    'make_examples_workers': 128,
+    'make_examples_cores_per_worker': 1,
+    'tpu': True
+}
+# Common computational flag values across all BAM categories.
+_RAM_PER_CORE = 4
+_MAKE_EXAMPLES_DISK_PER_WORKER = 200
+_CALL_VARIANTS_DISK_PER_WORKER = 50
+_POSTPROCESS_VARIANTS_DISK_GVCF = 200
 
 
 def _get_staging_examples_folder_to_write(pipeline_args,
@@ -277,6 +335,22 @@ def _gcs_object_exist(gcs_obj_path):
     return False
 
 
+def _get_gcs_object_size(gcs_obj_path):
+  """Returns the size of the given GCS object.
+
+  Args:
+    gcs_obj_path: (str) a path to an obj on GCS.
+  """
+  storage_client = storage.Client()
+  bucket_name = _get_gcs_bucket(gcs_obj_path)
+  obj_name = _get_gcs_relative_path(gcs_obj_path)
+  bucket = storage_client.get_bucket(bucket_name)
+  blob = bucket.get_blob(obj_name)
+  if blob.exists():
+    return blob.size
+  return 0
+
+
 def _can_write_to_bucket(bucket_name):
   """Returns True if caller is authorized to write into the bucket.
 
@@ -321,6 +395,83 @@ def _get_gcs_relative_path(gcs_path):
   return urlparse.urlparse(gcs_path).path.strip('/')
 
 
+def _get_bam_category(pipeline_args):
+  """Returns the category that input BAM files belongs to."""
+  bam_size = _get_gcs_object_size(pipeline_args.bam)
+  if bam_size == 0:
+    logging.error('Size of input bam file is 0.')
+
+  is_wes = pipeline_args.model.find(_WES_MODEL_IDENTIFIER) != -1
+  is_wgs = pipeline_args.model.find(_WGS_MODEL_IDENTIFIER) != -1
+
+  if is_wes:
+    if bam_size < _WES_LARGE_THR:
+      return BamCategories.WES_SMALL
+    else:
+      return BamCategories.WES_LARGE
+
+  if is_wgs:
+    if bam_size < _WGS_SMALL_THR:
+      return BamCategories.WGS_SMALL
+    elif bam_size > _WGS_LARGE_THR:
+      return BamCategories.WGS_LARGE
+    else:
+      return BamCategories.WGS_MEDIUM
+
+
+def _set_args_using_optimized_default_flags(default_flags, pipeline_args):
+  """Sets pipeline args using the set of given default flag values."""
+  pipeline_args.shards = (
+      default_flags['make_examples_workers'] *
+      default_flags['make_examples_cores_per_worker'])
+  pipeline_args.make_examples_workers = (default_flags['make_examples_workers'])
+  pipeline_args.make_examples_cores_per_worker = (
+      default_flags['make_examples_cores_per_worker'])
+  pipeline_args.make_examples_ram_per_worker_gb = (
+      default_flags['make_examples_cores_per_worker'] * _RAM_PER_CORE)
+  pipeline_args.make_examples_disk_per_worker_gb = (
+      _MAKE_EXAMPLES_DISK_PER_WORKER)
+  if 'gpu' in default_flags:
+    pipeline_args.gpu = default_flags['gpu']
+    pipeline_args.call_variants_workers = (
+        default_flags['call_variants_workers'])
+    pipeline_args.call_variants_cores_per_worker = (
+        default_flags['call_variants_cores_per_worker'])
+    pipeline_args.call_variants_ram_per_worker_gb = (
+        default_flags['call_variants_cores_per_worker'] * _RAM_PER_CORE)
+    pipeline_args.call_variants_disk_per_worker_gb = (
+        _CALL_VARIANTS_DISK_PER_WORKER)
+  elif 'tpu' in default_flags:
+    pipeline_args.tpu = default_flags['tpu']
+    pipeline_args.gke_cluster_zone = pipeline_args.zones[0]
+  else:
+    raise ValueError('Either gpu or tpu is needed for default flag settings.')
+  # Following flags are independent of BAM file category.
+  pipeline_args.preemptible = True
+  if pipeline_args.gvcf_outfile:
+    pipeline_args.postprocess_variants_disk_gb = _POSTPROCESS_VARIANTS_DISK_GVCF
+
+
+def _set_computational_flags_based_on_bam_size(pipeline_args):
+  """Automatically sets computational flags based on size of input BAM file."""
+  # First validating all necessary flags are present.
+  if not (pipeline_args.docker_image and pipeline_args.docker_image_gpu):
+    raise ValueError('both --docker_image and --docker_image_gpu must be '
+                     'provided with --set_optimized_flags_based_on_bam_size')
+  is_wes = pipeline_args.model.find(_WES_MODEL_IDENTIFIER) != -1
+  is_wgs = pipeline_args.model.find(_WGS_MODEL_IDENTIFIER) != -1
+  if is_wes == is_wgs:
+    raise ValueError('Unable to automatically set computational flags. Given '
+                     'model is neither WGS nor WES: %s' % pipeline_args.model)
+  if not pipeline_args.bam.endswith(_BAM_FILE_SUFFIX):
+    raise ValueError(
+        'Only able to automatically set computational flags for BAM files.')
+
+  bam_category = _get_bam_category(pipeline_args)
+  _set_args_using_optimized_default_flags(_DEFAULT_FLAGS[bam_category],
+                                          pipeline_args)
+
+
 def _run_make_examples(pipeline_args):
   """Runs the make_examples job."""
 
@@ -355,6 +506,8 @@ def _run_make_examples(pipeline_args):
       extra_args.extend(['--sample_name', pipeline_args.sample_name])
     if pipeline_args.hts_block_size:
       extra_args.extend(['--hts_block_size', str(pipeline_args.hts_block_size)])
+    if pipeline_args.bam.endswith(_CRAM_FILE_SUFFIX):
+      extra_args.extend(['--use_ref_for_cram'])
     return extra_args
 
   if pipeline_args.gcsfuse:
@@ -612,6 +765,8 @@ def _run_postprocess_variants(pipeline_args):
 
 def _validate_and_complete_args(pipeline_args):
   """Validates pipeline arguments and fills some missing args (if any)."""
+  if pipeline_args.set_optimized_flags_based_on_bam_size:
+    _set_computational_flags_based_on_bam_size(pipeline_args)
   # Basic validation logic. More detailed validation is done by pipelines API.
   if pipeline_args.preemptible and pipeline_args.max_preemptible_tries <= 0:
     raise ValueError('--max_preemptible_tries must be greater than zero.')
@@ -829,6 +984,15 @@ def run(argv=None):
       help=('Optional. If non-zero, specifies the time interval in seconds for '
             'writing workers log. Otherwise, log is written when the job is '
             'finished.'))
+  parser.add_argument(
+      '--set_optimized_flags_based_on_bam_size',
+      default=False,
+      action='store_true',
+      help=('Automatically sets the best values for computational flags, such '
+            'as number of workers, number of cores, amount of ram and disk per '
+            'worker for both make_examples and call_variants steps based on '
+            'the size of input BAM file. This flag also automatically decides '
+            'whether to use TPU or GPU for call_variants stage.'))
 
   # Optional GPU args.
   parser.add_argument(


### PR DESCRIPTION
In order to make execution of DeepVariant easier for new users, we introduced an automatic method for setting computational flags based on the size of input BAM file.

This is our best effort to reduce the cost of running DeepVariant. We ran extensive profiling experiments to find the optimal settings for both WGS and WES inputs.