### PR TITLE
Prepare release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,15 +3,12 @@
 
 # Install pipelines tool.
 FROM golang:1.11
-RUN go get -ldflags '-extldflags "-fno-PIC -static"' -buildmode pie -tags 'osusergo netgo static_build' github.com/googlegenomics/pipelines-tools/pipelines
+RUN go get github.com/googlegenomics/pipelines-tools/pipelines
 
 FROM google/cloud-sdk:alpine
 
 # Copy pipelines tool from the previous step.
 COPY --from=0 /go/bin/pipelines /usr/bin
-
-ARG commit_sha
-ENV COMMIT_SHA=${commit_sha}
 
 RUN apk add --update python3 python3-dev build-base && \
     ln -sf python3 /usr/bin/python && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,31 +4,20 @@
 # Install pipelines tool.
 FROM golang:1.11
 RUN go get -ldflags '-extldflags "-fno-PIC -static"' -buildmode pie -tags 'osusergo netgo static_build' github.com/googlegenomics/pipelines-tools/pipelines
-#FROM golang:1.10
-#ENV GOPATH /go
-#RUN go get github.com/googlegenomics/pipelines-tools/pipelines
-
 
 FROM google/cloud-sdk:alpine
 
 # Copy pipelines tool from the previous step.
 COPY --from=0 /go/bin/pipelines /usr/bin
-#ENV GOPATH /go
-#COPY --from=0 /go/ $GOPATH
-#ENV PATH $PATH:$GOPATH/bin
+
+ARG commit_sha
+ENV COMMIT_SHA=${commit_sha}
 
 RUN apk add --update python3 python3-dev build-base && \
     ln -sf python3 /usr/bin/python && \
     pip3 install --upgrade pip enum34 retrying google-api-core google-cloud-storage && \
     mkdir -p /opt/deepvariant_runner/bin && \
     mkdir -p /opt/deepvariant_runner/src
-
-# Kubernetes TPU is in beta.
-#RUN gcloud components install beta -q
-
-# Install kubernetes.
-#RUN curl -L -o /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/latest.txt)/bin/linux/amd64/kubectl && \
-#    chmod +x /usr/bin/kubectl
 
 ADD LICENSE /
 ADD gcp_deepvariant_runner.py /opt/deepvariant_runner/src/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,17 +2,20 @@
 # the Google Cloud Platform.
 
 # Install pipelines tool.
-FROM golang:1.10
-ENV GOPATH /go
-RUN go get github.com/googlegenomics/pipelines-tools/pipelines
+FROM golang:1.11
+RUN go get -ldflags '-extldflags "-fno-PIC -static"' -buildmode pie -tags 'osusergo netgo static_build' github.com/googlegenomics/pipelines-tools/pipelines
+#FROM golang:1.10
+#ENV GOPATH /go
+#RUN go get github.com/googlegenomics/pipelines-tools/pipelines
 
 
 FROM google/cloud-sdk:alpine
 
 # Copy pipelines tool from the previous step.
-ENV GOPATH /go
-COPY --from=0 /go/ $GOPATH
-ENV PATH $PATH:$GOPATH/bin
+COPY --from=0 /go/bin/pipelines /usr/bin
+#ENV GOPATH /go
+#COPY --from=0 /go/ $GOPATH
+#ENV PATH $PATH:$GOPATH/bin
 
 RUN apk add --update python3 python3-dev build-base && \
     ln -sf python3 /usr/bin/python && \
@@ -21,11 +24,11 @@ RUN apk add --update python3 python3-dev build-base && \
     mkdir -p /opt/deepvariant_runner/src
 
 # Kubernetes TPU is in beta.
-RUN gcloud components install beta -q
+#RUN gcloud components install beta -q
 
 # Install kubernetes.
-RUN curl -L -o /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/latest.txt)/bin/linux/amd64/kubectl && \
-    chmod +x /usr/bin/kubectl
+#RUN curl -L -o /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/latest.txt)/bin/linux/amd64/kubectl && \
+#    chmod +x /usr/bin/kubectl
 
 ADD LICENSE /
 ADD gcp_deepvariant_runner.py /opt/deepvariant_runner/src/

--- a/cloudbuild-release.yaml
+++ b/cloudbuild-release.yaml
@@ -1,5 +1,5 @@
 substitutions:
-    _PUBLIC_PROJECT_ID: cloud-genomics-pipelines
+    _PUBLIC_PROJECT_ID: cloud-lifesciences
 
 steps:
 - name: 'gcr.io/cloud-builders/docker'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,5 @@
 substitutions:
-    _MODEL: gs://deepvariant/models/DeepVariant/0.7.2/DeepVariant-inception_v3-0.7.2+data-wgs_standard
+    _MODEL: gs://deepvariant/models/DeepVariant/0.8.0/DeepVariant-inception_v3-0.8.0+data-wgs_standard
 
 steps:
 - name: 'gcr.io/cloud-builders/docker'
@@ -29,15 +29,5 @@ steps:
     - '${COMMIT_SHA}'
     - '${_MODEL}'
     - 'gpu'
-
-- name: 'gcr.io/${PROJECT_ID}/gcp-deepvariant-runner:${COMMIT_SHA}'
-  id: 'test-image-tpu'
-  args:
-    - 'bash'
-    - '/opt/deepvariant_runner/bin/run_and_verify.sh'
-    - '${PROJECT_ID}'
-    - '${COMMIT_SHA}'
-    - '${_MODEL}'
-    - 'tpu'
 
 timeout: 2h


### PR DESCRIPTION
Modify our dockerfile and cloudbuild yaml files to prepare for our new release process. Detailed list of changes:
* Update golang from 1.10 to 1.11
* Remove all Kubernetes components needed for TPU runs
* Remove TPU integration test
* Update our public container registry GCP project to `cloud-lifesciences` (which is consistent with the rest of products under [Google Genomics](https://github.com/googlegenomics))